### PR TITLE
fix(auth.auth_email_passwordless): fix broken login functionality

### DIFF
--- a/modules/auth/scripts/auth_email_passwordless.ts
+++ b/modules/auth/scripts/auth_email_passwordless.ts
@@ -19,16 +19,17 @@ export async function run(
 
 	if (!ctx.userConfig.email) throw new RuntimeError("provider_disabled");
 
+	// Check if the email is already associated with an identity
+	const existingIdentity = await ctx.db.emailPasswordless.findFirst({
+		where: { email: req.email },
+	});
+
 	// Fetch existing user if session token is provided
-	let userId: string | undefined;
+	let userId: string | undefined = existingIdentity?.userId;
+
 	if (req.userToken) {
 		const authRes = await ctx.modules.users.authenticateUser({
 			userToken: req.userToken,
-		});
-
-		// Check if the email is already associated with an identity
-		const existingIdentity = await ctx.db.emailPasswordless.findFirst({
-			where: { email: req.email },
 		});
 
 		if (existingIdentity && existingIdentity.userId !== authRes.userId) {

--- a/modules/auth/scripts/auth_email_passwordless.ts
+++ b/modules/auth/scripts/auth_email_passwordless.ts
@@ -22,7 +22,7 @@ export async function run(
 	// Fetch existing user if session token is provided
 	let userId: string | undefined;
 	if (req.userToken) {
-		const { userId } = await ctx.modules.users.authenticateUser({
+		const authRes = await ctx.modules.users.authenticateUser({
 			userToken: req.userToken,
 		});
 
@@ -30,9 +30,12 @@ export async function run(
 		const existingIdentity = await ctx.db.emailPasswordless.findFirst({
 			where: { email: req.email },
 		});
-		if (existingIdentity && existingIdentity.userId !== userId) {
+
+		if (existingIdentity && existingIdentity.userId !== authRes.userId) {
 			throw new RuntimeError("email_already_used");
 		}
+
+		userId = authRes.userId;
 	}
 
 	// Create verification

--- a/modules/auth/tests/e2e.ts
+++ b/modules/auth/tests/e2e.ts
@@ -3,54 +3,73 @@ import { assertEquals } from "https://deno.land/std@0.208.0/assert/mod.ts";
 import { faker } from "https://deno.land/x/deno_faker@v1.0.3/mod.ts";
 
 test("e2e", async (ctx: TestContext) => {
-	const authRes = await ctx.modules.auth.authEmailPasswordless({
-		email: faker.internet.email(),
-	});
-
-	// Look up correct code
-	const { code } = await ctx.db.emailPasswordlessVerification.findFirstOrThrow({
-		where: {
-			id: authRes.verification.id,
-		},
-	});
-
-	const verifyRes = await ctx.modules.auth.verifyEmailPasswordless({
-		verificationId: authRes.verification.id,
-		code: code,
-	});
-	assertEquals(verifyRes.token.type, "user");
-});
-
-
-test("e2e with user token", async (ctx: TestContext) => {
+	// First we create a new user, and "register" into the auth
+	// using an authEmailPasswordless({ email, userToken })
+	// call
 	const { user } = await ctx.modules.users.createUser({});
 
 	const { token: session } = await ctx.modules.users.createUserToken({
 		userId: user.id
 	});
 
-	const authRes = await ctx.modules.auth.authEmailPasswordless({
-		email: faker.internet.email(),
-		userToken: session.token
-	});
+	const fakeEmail = faker.internet.email();
 
-	// Look up correct code
-	const { code } = await ctx.db.emailPasswordlessVerification.findFirstOrThrow({
-		where: {
-			id: authRes.verification.id,
-		},
-	});
+	// Now we test that post-signin, we get the same user
+	{
+		const authRes = await ctx.modules.auth.authEmailPasswordless({
+			email: fakeEmail,
+			userToken: session.token
+		});
 
-	const verifyRes = await ctx.modules.auth.verifyEmailPasswordless({
-		verificationId: authRes.verification.id,
-		code: code,
-	});
+		// Look up correct code
+		const { code } = await ctx.db.emailPasswordlessVerification.findFirstOrThrow({
+			where: {
+				id: authRes.verification.id,
+			},
+		});
 
-	assertEquals(verifyRes.token.type, "user");
+		// Now by verifying the email, we register, and can also use
+		// this to verify the token
+		const verifyRes = await ctx.modules.auth.verifyEmailPasswordless({
+			verificationId: authRes.verification.id,
+			code: code,
+		});
 
-	const verifyRes2 = await ctx.modules.users.authenticateUser({
-		userToken: verifyRes.token.token
-	});
+		assertEquals(verifyRes.token.type, "user");
 
-	assertEquals(verifyRes2.userId, user.id);
+
+		// Make sure we end up with the same user we started with
+		const verifyRes2 = await ctx.modules.users.authenticateUser({
+			userToken: verifyRes.token.token
+		});
+
+		assertEquals(verifyRes2.userId, user.id);
+	}
+
+	// Now we try logging back in with the same email,
+	// but without a token, expecting the same user
+	{
+		const authRes = await ctx.modules.auth.authEmailPasswordless({
+			email: fakeEmail
+		});
+
+		// Look up correct code
+		const { code: code } = await ctx.db.emailPasswordlessVerification.findFirstOrThrow({
+			where: {
+				id: authRes.verification.id,
+			},
+		});
+
+		const verifyRes = await ctx.modules.auth.verifyEmailPasswordless({
+			verificationId: authRes.verification.id,
+			code: code,
+		});
+
+		const verifyRes2 = await ctx.modules.users.authenticateUser({
+			userToken: verifyRes.token.token
+		});
+
+		assertEquals(verifyRes2.userId, user.id);	
+	}
 });
+

--- a/modules/auth/tests/e2e.ts
+++ b/modules/auth/tests/e2e.ts
@@ -20,3 +20,37 @@ test("e2e", async (ctx: TestContext) => {
 	});
 	assertEquals(verifyRes.token.type, "user");
 });
+
+
+test("e2e with user token", async (ctx: TestContext) => {
+	const { user } = await ctx.modules.users.createUser({});
+
+	const { token: session } = await ctx.modules.users.createUserToken({
+		userId: user.id
+	});
+
+	const authRes = await ctx.modules.auth.authEmailPasswordless({
+		email: faker.internet.email(),
+		userToken: session.token
+	});
+
+	// Look up correct code
+	const { code } = await ctx.db.emailPasswordlessVerification.findFirstOrThrow({
+		where: {
+			id: authRes.verification.id,
+		},
+	});
+
+	const verifyRes = await ctx.modules.auth.verifyEmailPasswordless({
+		verificationId: authRes.verification.id,
+		code: code,
+	});
+
+	assertEquals(verifyRes.token.type, "user");
+
+	const verifyRes2 = await ctx.modules.users.authenticateUser({
+		userToken: verifyRes.token.token
+	});
+
+	assertEquals(verifyRes2.userId, user.id);
+});


### PR DESCRIPTION
`userToken` parameter in Request was practically being ignored, this PR puts it to use in the database